### PR TITLE
Add SPM manifest and rewrite request access functionality

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,21 @@
+// swift-tools-version:4.2
+
+import PackageDescription
+
+let name = "PMKEventKit"
+
+let pkg = Package(name: name)
+pkg.products = [
+    .library(name: name, targets: [name]),
+]
+pkg.swiftLanguageVersions = [.v4, .v4_2]
+pkg.dependencies = [
+	.package(url: "https://github.com/mxcl/PromiseKit.git", from: "6.0.0")
+]
+
+let target: Target = .target(name: name)
+target.path = "Sources"
+target.exclude = ["Tests"]
+target.dependencies = ["PromiseKit"]
+
+pkg.targets = [target]

--- a/Sources/EKEventStore+Promise.swift
+++ b/Sources/EKEventStore+Promise.swift
@@ -11,27 +11,7 @@ import EventKit
 import PromiseKit
 #endif
 
-/// Errors representing PromiseKit EventKit failures
-public enum EventKitError: Error, CustomStringConvertible {
-    /// Access to the EKEventStore is restricted
-    case restricted
-    /// Access to the EKEventStore is denied
-    case denied
-
-    /// A textual description of the EKEventStore error
-    public var description: String {
-        switch self {
-        case .restricted:
-            return "A head of family must grant calendar access."
-        case .denied:
-            return "Calendar access has been denied."
-        }
-    }
-}
-
 /**
- Requests access to the event store.
-
  To import `EKEventStore`:
 
      pod "PromiseKit/EventKit"
@@ -39,28 +19,21 @@ public enum EventKitError: Error, CustomStringConvertible {
  And then in your sources:
 
      import PromiseKit
-
- - Returns: A promise that fulfills with the EKEventStore.
  */
-public func EKEventStoreRequestAccess() -> Promise<EKEventStore> {
-    return Promise { seal in
-        let eventStore = EKEventStore()
+extension EKEventStore {
 
-        switch EKEventStore.authorizationStatus(for: .event) {
-        case .authorized:
-            seal.fulfill(eventStore)
-        case .denied:
-            seal.reject(EventKitError.denied)
-        case .restricted:
-            seal.reject(EventKitError.restricted)
-        case .notDetermined:
-            eventStore.requestAccess(to: .event) { granted, error in
-                if granted {
-                    seal.fulfill(eventStore)
-                } else if let error = error {
+    /**
+     Requests access to the event store.
+
+     - Returns: A promise that fulfills with the resulting EKAuthorizationStatus.
+     */
+    public func requestAccess(to entityType: EKEntityType) -> Promise<EKAuthorizationStatus> {
+        return Promise { seal in
+            requestAccess(to: entityType) { granted, error in
+                if let error = error {
                     seal.reject(error)
                 } else {
-                    seal.reject(EventKitError.denied)
+                    seal.fulfill(EKEventStore.authorizationStatus(for: entityType))
                 }
             }
         }

--- a/Tests/TestEventKit.swift
+++ b/Tests/TestEventKit.swift
@@ -9,10 +9,10 @@ class Test_EventKit_Swift: XCTestCase {
             //FIXME can't make this succeed on Travis :(
             // needs Entitlements, but then I can't get it to sign
             // so, we'll just test linkage
-            EKEventStoreRequestAccess()
+            EKEventStore().requestAccess(to: .event)
         #else
             let ex = expectation(description: "")
-            EKEventStoreRequestAccess().ensure(ex.fulfill)
+            EKEventStore().requestAccess(to: .event).ensure(ex.fulfill)
             waitForExpectations(timeout: 30)
         #endif
     }


### PR DESCRIPTION
This PR does two things, in order to finish what was discussed in https://github.com/mxcl/PromiseKit/issues/999.

1. Added an SPM manifest for v4.2. I _tried_ adding one for v3 as well, but when testing it with 3.1.1 in swiftenv it wouldn't build PromiseKit for some reason. I don't have an old Xcode installed right now. Maybe Travis can help with this in the future. I decided to only add the v4.2 manifest for now since it's still an addition to the project and I could verify it.
2. Changed the request access function to an extension method on EKEventStore. This matches what was discussed in the linked PMK issue. `EventKitError` was also removed because it wasn't necessary anymore.

I'd also like to update Travis so that it verifies `swift build` like the other extension repos, but I'm not familiar with the more complex configs they use, so I might take a stab at it in another PR.

Closes https://github.com/mxcl/PromiseKit/issues/999